### PR TITLE
Update attrs.xml

### DIFF
--- a/uikit/src/main/res/values/attrs.xml
+++ b/uikit/src/main/res/values/attrs.xml
@@ -71,7 +71,7 @@
     </declare-styleable>
 
     <declare-styleable name="AspectRatioImageView">
-        <attr name="aspectRatio" format="float" />
+        <attr name="aspectRatio" format="string" />
         <attr name="aspectRatioEnabled" format="boolean" />
         <attr name="dominantMeasurement">
             <enum name="width" value="0" />


### PR DESCRIPTION
Fix error  AAPT: String types not allowed (at 'aspectRatio' with value '4:3') when use uikit with react-native-camera