### PR TITLE
PAYP-569

### DIFF
--- a/demo/src/main/java/com/midtrans/demo/DemoConfigActivity.java
+++ b/demo/src/main/java/com/midtrans/demo/DemoConfigActivity.java
@@ -7,9 +7,11 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.AppCompatRadioButton;
@@ -2917,6 +2919,8 @@ public class DemoConfigActivity extends AppCompatActivity implements Transaction
         autoReadSmsEnabledSelection.setSupportButtonTintList(colorStateList);
     }
 
+    //setLanguage to either "en" for english or "id" for bahasa
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
     private void initMidtransSDK() {
         SdkUIFlowBuilder.init()
                 .setContext(this)
@@ -2927,6 +2931,7 @@ public class DemoConfigActivity extends AppCompatActivity implements Transaction
                 .setDefaultText("fonts/SourceSansPro-Regular.ttf")
                 .setBoldText("fonts/SourceSansPro-Bold.ttf")
                 .setSemiBoldText("fonts/SourceSansPro-Semibold.ttf")
+                .setLanguage("en")
                 .buildSDK();
     }
 

--- a/uikit/README.md
+++ b/uikit/README.md
@@ -19,6 +19,7 @@ Besides [initialization step](https://github.com/veritrans/veritrans-android/wik
 To initialize the UI kit SDK, use these codes.
 
 ```Java
+//setLanguage to either "en" for english or "id" for bahasa
 SdkUIFlowBuilder.init(this, CLIENT_KEY, BASE_URL, new TransactionFinishedCallback() {
 	@Override
    public void onTransactionFinished(TransactionResult result) {
@@ -30,6 +31,7 @@ SdkUIFlowBuilder.init(this, CLIENT_KEY, BASE_URL, new TransactionFinishedCallbac
 		.setDefaultText("open_sans_regular.ttf")
 		.setSemiBoldText("open_sans_semibold.ttf")
 		.setBoldText("open_sans_bold.ttf")
+		.setLanguage("en")
 		.buildSDK();
 ```
 
@@ -66,6 +68,10 @@ Then to ensure this replace library theme, please add these lines into your `And
         android:theme="AppTheme"
         tools:replace="android:theme">
 ```
+
+## Language customization
+In order to force the SDK to change to Bahasa, we can use `.setLanguage("id")` when we init the `SdkUIFlowBuilder`
+"en" for english or "id" for Bahasa
 
 ## Starting UI Flow
 

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/SdkUIFlowBuilder.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/SdkUIFlowBuilder.java
@@ -1,6 +1,10 @@
 package com.midtrans.sdk.uikit;
 
 import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 
 import com.midtrans.sdk.corekit.callback.TransactionFinishedCallback;
 import com.midtrans.sdk.corekit.core.BaseSdkBuilder;
@@ -10,6 +14,7 @@ import com.midtrans.sdk.corekit.core.themes.CustomColorTheme;
 import com.midtrans.sdk.corekit.models.PaymentMethodsModel;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * Created by ziahaqi on 15/06/2016.
@@ -123,6 +128,24 @@ public class SdkUIFlowBuilder extends BaseSdkBuilder<SdkUIFlowBuilder> {
 
     public SdkUIFlowBuilder setColorTheme(CustomColorTheme customColorTheme) {
         this.colorTheme = customColorTheme;
+        return this;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public SdkUIFlowBuilder setLanguage(String languageCode) {
+        Resources resources = context.getResources();
+        Locale currentLocale = resources.getConfiguration().locale;
+        Locale englishLocale = new Locale("en");
+        Locale locale;
+        if(!languageCode.equals("en") && !languageCode.equals("id")) {
+            locale = englishLocale;
+        } else {
+            locale = new Locale(languageCode);
+        }
+        Locale.setDefault(currentLocale);
+        Configuration config = resources.getConfiguration();
+        config.setLocale(locale);
+        resources.updateConfiguration(config, resources.getDisplayMetrics());
         return this;
     }
 }


### PR DESCRIPTION
Builder function to set locale for the SDK. 
It can be set to either "en" for english or "id" for bahasa
If not these 2, it will be set to English