### PR TITLE
Fix Other Bank transfer not handling BRI as other_va_processor 

### DIFF
--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -15,7 +15,11 @@ import com.midtrans.sdk.uikit.utilities.UiKitConstants;
 public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     private static final String LABEL_BANK_CODE_BNI = "009 (Bank BNI)";
+    private static final String LABEL_BANK_CODE_BRI = "002 (Bank BRI)";
     private static final String LABEL_BANK_CODE_PERMATA = "013 (Bank Permata)";
+
+    private static final String BNI = "bni";
+    private static final String BRI = "bri";
 
     private final String bankType;
 
@@ -111,11 +115,14 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
     }
 
     public String getBankCode() {
-        String bankCode = LABEL_BANK_CODE_BNI;
+        String bankCode;
+        String bank = transactionResponse.getAccountNumbers().get(0).getBank();
 
-        MerchantPreferences preferences = getMidtransSDK().getMerchantData().getPreference();
-        if (preferences != null && !TextUtils.isEmpty(preferences.getOtherVaProcessor())
-                && preferences.getOtherVaProcessor().equals(UiKitConstants.OTHER_VA_PROCESSOR_PERMATA)) {
+        if (bank.equals(BRI)) {
+            bankCode = LABEL_BANK_CODE_BRI;
+        } else if (bank.equals(BNI)) {
+            bankCode = LABEL_BANK_CODE_BNI;
+        } else {
             bankCode = LABEL_BANK_CODE_PERMATA;
         }
 

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -4,8 +4,11 @@ import android.text.TextUtils;
 
 import com.midtrans.sdk.corekit.core.PaymentType;
 import com.midtrans.sdk.corekit.models.TransactionResponse;
+import com.midtrans.sdk.corekit.models.VaNumber;
 import com.midtrans.sdk.uikit.abstracts.BasePaymentPresenter;
 import com.midtrans.sdk.uikit.utilities.UiKitConstants;
+
+import java.util.Map;
 
 /**
  * Created by ziahaqi on 8/15/17.
@@ -19,6 +22,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     private static final String BNI = "bni";
     private static final String BRI = "bri";
+    private static final String PERMATA = "permata";
 
     private final String bankType;
 
@@ -77,15 +81,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
                     expiration = transactionResponse.getPermataExpiration();
                     break;
                 case PaymentType.ALL_VA:
-                    String bank = transactionResponse.getAccountNumbers().get(0).getBank();
-
-                    if (bank.equals(BRI)) {
-                        expiration = transactionResponse.getBriExpiration();
-                    } else if (bank.equals(BNI)) {
-                        expiration = transactionResponse.getBniExpiration();
-                    } else {
-                        expiration = transactionResponse.getPermataExpiration();
-                    }
+                    expiration = getOtherBankVAExpiration();
                     break;
                 case PaymentType.BNI_VA:
                     expiration = transactionResponse.getBniExpiration();
@@ -140,5 +136,29 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
         }
 
         return bankCode;
+    }
+
+    private String getOtherBankVAExpiration() {
+
+        String expiration = "";
+        String otherVaProcessor = getOtherVaProcessor();
+
+        switch (otherVaProcessor) {
+            case BRI:
+                expiration = transactionResponse.getBriExpiration();
+                break;
+            case BNI:
+                expiration = transactionResponse.getBniExpiration();
+                break;
+            case PERMATA:
+                expiration = transactionResponse.getPermataExpiration();
+                break;
+        }
+
+        return expiration;
+    }
+
+    private String getOtherVaProcessor() {
+        return transactionResponse.getAccountNumbers().get(0).getBank();
     }
 }

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -44,15 +44,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
                     vaNumber = transactionResponse.getPermataVANumber();
                     break;
                 case PaymentType.ALL_VA:
-                    String bank = transactionResponse.getAccountNumbers().get(0).getBank();
-
-                    if (bank.equals(BRI)) {
-                        vaNumber = transactionResponse.getBriVaNumber();
-                    } else if (bank.equals(BNI)) {
-                        vaNumber = transactionResponse.getBniVaNumber();
-                    } else {
-                        vaNumber = transactionResponse.getPermataVANumber();
-                    }
+                    vaNumber = getOtherBankVANumber();
                     break;
                 case PaymentType.BNI_VA:
                     vaNumber = transactionResponse.getBniVaNumber();
@@ -124,15 +116,20 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
     }
 
     public String getBankCode() {
-        String bankCode;
-        String bank = transactionResponse.getAccountNumbers().get(0).getBank();
 
-        if (bank.equals(BRI)) {
-            bankCode = LABEL_BANK_CODE_BRI;
-        } else if (bank.equals(BNI)) {
-            bankCode = LABEL_BANK_CODE_BNI;
-        } else {
-            bankCode = LABEL_BANK_CODE_PERMATA;
+        String bankCode = "";
+        String bank = getOtherVaProcessor();
+
+        switch (bank) {
+            case BRI:
+                bankCode = LABEL_BANK_CODE_BRI;
+                break;
+            case BNI:
+                bankCode = LABEL_BANK_CODE_BNI;
+                break;
+            case PERMATA:
+                bankCode = LABEL_BANK_CODE_PERMATA;
+                break;
         }
 
         return bankCode;
@@ -156,6 +153,26 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
         }
 
         return expiration;
+    }
+
+    private String getOtherBankVANumber() {
+
+        String vaNumber = "";
+        String otherVaProcessor = getOtherVaProcessor();
+
+        switch (otherVaProcessor) {
+            case BRI:
+                vaNumber = transactionResponse.getBriVaNumber();
+                break;
+            case BNI:
+                vaNumber = transactionResponse.getBniVaNumber();
+                break;
+            case PERMATA:
+                vaNumber = transactionResponse.getPermataVANumber();
+                break;
+        }
+
+        return vaNumber;
     }
 
     private String getOtherVaProcessor() {

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -4,11 +4,8 @@ import android.text.TextUtils;
 
 import com.midtrans.sdk.corekit.core.PaymentType;
 import com.midtrans.sdk.corekit.models.TransactionResponse;
-import com.midtrans.sdk.corekit.models.VaNumber;
 import com.midtrans.sdk.uikit.abstracts.BasePaymentPresenter;
 import com.midtrans.sdk.uikit.utilities.UiKitConstants;
-
-import java.util.Map;
 
 /**
  * Created by ziahaqi on 8/15/17.

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -41,8 +41,15 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
                     vaNumber = transactionResponse.getPermataVANumber();
                     break;
                 case PaymentType.ALL_VA:
-                    //VA number is based on other VA processor
-                    vaNumber = TextUtils.isEmpty(transactionResponse.getBniVaNumber()) ? transactionResponse.getPermataVANumber() : transactionResponse.getBniVaNumber();
+                    String bank = transactionResponse.getAccountNumbers().get(0).getBank();
+
+                    if (bank.equals(BRI)) {
+                        vaNumber = transactionResponse.getBriVaNumber();
+                    } else if (bank.equals(BNI)) {
+                        vaNumber = transactionResponse.getBniVaNumber();
+                    } else {
+                        vaNumber = transactionResponse.getPermataVANumber();
+                    }
                     break;
                 case PaymentType.BNI_VA:
                     vaNumber = transactionResponse.getBniVaNumber();

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -19,7 +19,6 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     private static final String BNI = "bni";
     private static final String BRI = "bri";
-    private static final String PERMATA = "permata";
 
     private final String bankType;
 
@@ -114,7 +113,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     public String getBankCode() {
 
-        String bankCode = "";
+        String bankCode;
         String bank = getOtherVaProcessor();
 
         switch (bank) {
@@ -124,7 +123,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
             case BNI:
                 bankCode = LABEL_BANK_CODE_BNI;
                 break;
-            case PERMATA:
+            default:
                 bankCode = LABEL_BANK_CODE_PERMATA;
                 break;
         }
@@ -134,7 +133,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     private String getOtherBankVAExpiration() {
 
-        String expiration = "";
+        String expiration;
         String otherVaProcessor = getOtherVaProcessor();
 
         switch (otherVaProcessor) {
@@ -144,7 +143,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
             case BNI:
                 expiration = transactionResponse.getBniExpiration();
                 break;
-            case PERMATA:
+            default:
                 expiration = transactionResponse.getPermataExpiration();
                 break;
         }
@@ -154,7 +153,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
 
     private String getOtherBankVANumber() {
 
-        String vaNumber = "";
+        String vaNumber;
         String otherVaProcessor = getOtherVaProcessor();
 
         switch (otherVaProcessor) {
@@ -164,7 +163,7 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
             case BNI:
                 vaNumber = transactionResponse.getBniVaNumber();
                 break;
-            case PERMATA:
+            default:
                 vaNumber = transactionResponse.getPermataVANumber();
                 break;
         }

--- a/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
+++ b/uikit/src/main/java/com/midtrans/sdk/uikit/views/banktransfer/status/BankTransferStatusPresenter.java
@@ -3,7 +3,6 @@ package com.midtrans.sdk.uikit.views.banktransfer.status;
 import android.text.TextUtils;
 
 import com.midtrans.sdk.corekit.core.PaymentType;
-import com.midtrans.sdk.corekit.models.MerchantPreferences;
 import com.midtrans.sdk.corekit.models.TransactionResponse;
 import com.midtrans.sdk.uikit.abstracts.BasePaymentPresenter;
 import com.midtrans.sdk.uikit.utilities.UiKitConstants;
@@ -78,8 +77,15 @@ public class BankTransferStatusPresenter extends BasePaymentPresenter {
                     expiration = transactionResponse.getPermataExpiration();
                     break;
                 case PaymentType.ALL_VA:
-                    //expiration is based on other VA processor
-                    expiration = TextUtils.isEmpty(transactionResponse.getBniExpiration()) ? transactionResponse.getPermataExpiration() : transactionResponse.getBniExpiration();
+                    String bank = transactionResponse.getAccountNumbers().get(0).getBank();
+
+                    if (bank.equals(BRI)) {
+                        expiration = transactionResponse.getBriExpiration();
+                    } else if (bank.equals(BNI)) {
+                        expiration = transactionResponse.getBniExpiration();
+                    } else {
+                        expiration = transactionResponse.getPermataExpiration();
+                    }
                     break;
                 case PaymentType.BNI_VA:
                     expiration = transactionResponse.getBniExpiration();


### PR DESCRIPTION
In this PR, we fix the other bank transfer when handling BRI as other_va_processor. Previously the highlighted area is not showing the expected behaviour.
1. Expiration showing **null**
2. Virtual Account Number not shown
3. Wrong Bank Code

Before:
![Untitled](https://user-images.githubusercontent.com/47908863/193741176-09f2e46a-3f5e-472f-a7d4-2ff99c47e274.png)


After:
![1664857127479](https://user-images.githubusercontent.com/47908863/193733652-d1ce4751-4569-413b-b5b2-60eade7fda1f.jpg)
